### PR TITLE
[fix]codexによるバリデーションバグ対応(Improve validation timing)

### DIFF
--- a/src/components/StylishBentoOrderService.tsx
+++ b/src/components/StylishBentoOrderService.tsx
@@ -54,7 +54,7 @@ export default function StylishBentoOrderService() {
   >([]);
   const [isOrdering, setIsOrdering] = useState(false);
 
-  const [showErrors, setShowErrors] = useState(false); // エラー表示フラグ
+  const [isShowErrors, setIsShowErrors] = useState(false); // エラー表示フラグ
 
   const {
     register,
@@ -103,7 +103,7 @@ export default function StylishBentoOrderService() {
   const errorMessage = errors.employeeId?.message;
 
   const handleBentoSelection = async (bentoId: string) => {
-    setShowErrors(true);
+    setIsShowErrors(true);
     const isValid = await trigger("employeeId");
     if (!isValid) {
       return;
@@ -128,7 +128,7 @@ export default function StylishBentoOrderService() {
         setOrders(updatedOrders);
         reset({ employeeId: "" });
         setSelectedBentoId(null);
-        setShowErrors(false);
+        setIsShowErrors(false);
       }
       setIsOrdering(false);
     }
@@ -179,12 +179,12 @@ export default function StylishBentoOrderService() {
             placeholder="社員番号を入力してください　(例:111)"
             className="w-full px-4 py-2 bg-gray-700 border border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-teal-500 text-gray-100 placeholder-gray-400"
             onBlur={() => {
-              setShowErrors(true);
+              setIsShowErrors(true);
               void trigger("employeeId");
             }}
           />
           {/* エラーメッセージの表示 */}
-          {errors.employeeId && showErrors && (
+          {errors.employeeId && isShowErrors && (
             <p className="mt-2 text-red-500">{errorMessage}</p>
           )}
         </div>


### PR DESCRIPTION
### 背景
codexの精度確認と、既知のバグ潰しを行う。

### 対応内容
3桁未満入力してフォーカスを外した際に、ボタンが活性化され、バリデーションエラーが出ていないバグの解消

### 動作確認
 下記で動作確認済み
  - 1桁半角数字を入力してフォーカスを外した際に、注文ボタンが活性化しないこと,バリデーションエラーが出ること
  - 2桁半角数字を入力してフォーカスを外した際に、注文ボタンが活性化しないこと,バリデーションエラーが出ること
  - 3桁以上6桁以下の半角数字を何パターンか入力してフォーカスを外した際に、注文ボタンが活性化すること,バリデーションエラーが出ないこと
  - 半角数字以外のパターン,7桁以上のパターンでも既存通りバリデーション出ること
  
  ### 補足
- AIエージェントとしてclaude codeを使いたいがすでにcopilotとGPT契約しているので、それらの精度確認後に時間のあるタイミングで検討したい。
- そのため、既知のバグ潰しのタスクを投げてみた。
- codexに下記を指示。
    - 2桁入力してフォーカスを外した際に、ボタンが活性化され、バリデーションエラーが出ていないので、それを修正して。
- 初回なこともあるが、codexには5回ほどタスクを投げ直し、30分ほどかかった。
- たしかにバグは途中で解消するが、求めていたコードではなかったので投げ直しとした。
- copilotのレビューはいつも通りの精度で、一応コメントくれるから安心感はある。みたいな精度。

### 把握した課題
- ブランチ名が日本語で生成されている。
    - GitHubで「Unicode エスケープ表現を使ってます。不可視の制御文字や異常な空白（例：ゼロ幅スペース）が紛れている可能性があります」とwarnが出てる。
    - Amplifyの自動ホスティングルール外なのでホスティングされてないが、/codex/**も追加したら問題起こりそう(URLエンコードなど何かしら問題起こりそう)
- PRのコメント見てくれない。(claudeなら見てくれる)

下記codexの自動生成
---
## Summary
- trigger validation on every change so the button disables as soon as input is invalid
- show validation messages only after blur or order attempt

## Testing
- `npx eslint -c .eslintrc.cjs --ext ts,tsx --report-unused-disable-directives --max-warnings 0 .` (fails: A config object is using the "root" key)
- `npm run build` (fails to find dependencies during TypeScript compile)
- `npm test` (fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_e_683ff5f549e08330b98f3a492843f2f3